### PR TITLE
Dc helprequests index page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
+import HelpRequestCreatePage from "main/pages/HelpRequests/HelpRequestCreatePage";
+import HelpRequestEditPage from "main/pages/HelpRequests/HelpRequestEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -65,6 +69,29 @@ function App() {
             exact
             path="/restaurants/create"
             element={<RestaurantCreatePage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/helprequests"
+            element={<HelpRequestIndexPage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/helprequests/edit/:id"
+            element={<HelpRequestEditPage />}
+          />
+          <Route
+            exact
+            path="/helprequests/create"
+            element={<HelpRequestCreatePage />}
           />
         </>
       )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -82,8 +82,6 @@ function App() {
             exact
             path="/helprequests"
             element={<HelpRequestIndexPage />}
-            path="/diningcommonsmenuitems"
-            element={<UCSBDiningCommonsMenuItemsIndexPage />}
           />
         </>
       )}
@@ -98,6 +96,22 @@ function App() {
             exact
             path="/helprequests/create"
             element={<HelpRequestCreatePage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/diningcommonsmenuitems"
+            element={<UCSBDiningCommonsMenuItemsIndexPage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
             path="/diningcommonsmenuitems/edit/:id"
             element={<UCSBDiningCommonsMenuItemsEditPage />}
           />

--- a/frontend/src/fixtures/helpRequestFixtures.js
+++ b/frontend/src/fixtures/helpRequestFixtures.js
@@ -2,7 +2,7 @@ const helpRequestFixtures = {
   oneRequest: {
     id: 1,
     requesterEmail: "dchen451@ucsb.edu",
-    teamID: "01",
+    teamId: "01",
     tableOrBreakoutRoom: "Table 1",
     requestTime: "2022-01-02T12:00:00",
     explanation: "I don't understand how to do the homework",
@@ -13,7 +13,7 @@ const helpRequestFixtures = {
     {
       id: 1,
       requesterEmail: "dchen451@ucsb.edu",
-      teamID: "01",
+      teamId: "01",
       tableOrBreakoutRoom: "Table 1",
       requestTime: "2022-01-02T12:00:00",
       explanation: "I don't understand how to do the homework",
@@ -22,7 +22,7 @@ const helpRequestFixtures = {
     {
       id: 2,
       requesterEmail: "davidchen@ucsb.edu",
-      teamID: "02",
+      teamId: "02",
       tableOrBreakoutRoom: "Table 2",
       requestTime: "2026-04-28T12:30:30",
       explanation: "I need help with the project",
@@ -31,7 +31,7 @@ const helpRequestFixtures = {
     {
       id: 3,
       requesterEmail: "johndoe@ucsb.edu",
-      teamID: "10",
+      teamId: "10",
       tableOrBreakoutRoom: "Table 10",
       requestTime: "2024-11-28T12:56:30",
       explanation: "I need help with the midterm",

--- a/frontend/src/main/components/HelpRequests/HelpRequestTable.jsx
+++ b/frontend/src/main/components/HelpRequests/HelpRequestTable.jsx
@@ -47,7 +47,7 @@ export default function HelpRequestTable({
 
     {
       header: "Team ID",
-      accessorKey: "teamID",
+      accessorKey: "teamId",
     },
 
     {

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -68,6 +68,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/ucsbdates">
                     UCSB Dates
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/helprequests">
+                    Help Requests
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>

--- a/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HelpRequestCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
@@ -1,11 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestForm from "main/components/HelpRequests/HelpRequestForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function HelpRequestCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (helpRequest) => ({
+    url: "/api/helprequests/post",
+    method: "POST",
+    params: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamID,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved,
+    },
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(
+      `New help request Created - id: ${helpRequest.id} explanation: ${helpRequest.explanation}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/helprequests/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequests" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Help Request</h1>
+        <HelpRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/HelpRequests/HelpRequestEditPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HelpRequestEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HelpRequestIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/helprequest/create">Create</a>
+        </p>
+        <p>
+          <a href="/helprequest/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
@@ -7,10 +7,10 @@ export default function HelpRequestIndexPage() {
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
         <p>
-          <a href="/helprequest/create">Create</a>
+          <a href="/helprequests/create">Create</a>
         </p>
         <p>
-          <a href="/helprequest/edit/1">Edit</a>
+          <a href="/helprequests/edit/1">Edit</a>
         </p>
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
@@ -1,17 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestTable from "main/components/HelpRequests/HelpRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function HelpRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: helpRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/helprequests/all"],
+    { method: "GET", url: "/api/helprequests/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/helprequests/create"
+          style={{ float: "right" }}
+        >
+          Create Help Request
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/helprequests/create">Create</a>
-        </p>
-        <p>
-          <a href="/helprequests/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Help Requests</h1>
+        <HelpRequestTable
+          helpRequests={helpRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequests/HelpRequestCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequests/HelpRequestCreatePage.stories.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestCreatePage from "main/pages/HelpRequests/HelpRequestCreatePage";
+
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+export default {
+  title: "pages/HelpRequests/HelpRequestCreatePage",
+  component: HelpRequestCreatePage,
+};
+
+const Template = () => <HelpRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/helprequests/post", () => {
+      return HttpResponse.json(helpRequestFixtures.oneRequest, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/HelpRequests/HelpRequestIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequests/HelpRequestIndexPage.stories.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
+
+export default {
+  title: "pages/HelpRequests/HelpRequestIndexPage",
+  component: HelpRequestIndexPage,
+};
+
+const Template = () => <HelpRequestIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeRequests);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeRequests);
+    }),
+    http.delete("/api/helprequests", () => {
+      return HttpResponse.json(
+        { message: "Help Request deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
@@ -31,7 +31,7 @@ describe("HelpRequestTable tests", () => {
   const expectedFields = [
     "id",
     "requesterEmail",
-    "teamID",
+    "teamId",
     "tableOrBreakoutRoom",
     "requestTime",
     "explanation",

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import HelpRequestCreatePage from "main/pages/HelpRequests/HelpRequestCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("HelpRequestCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
@@ -1,18 +1,39 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import HelpRequestCreatePage from "main/pages/HelpRequests/HelpRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("HelpRequestCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,15 +42,10 @@ describe("HelpRequestCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,11 +54,92 @@ describe("HelpRequestCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+  test("on submit, makes request to backend, and redirects to /helprequests", async () => {
+    const queryClient = new QueryClient();
+    const helpRequest = {
+      id: 3,
+      requesterEmail: "john.doe@ucsb.edu",
+      teamId: 1,
+      tableOrBreakoutRoom: "Table 5",
+      requestTime: "2023-10-10T10:00",
+      explanation: "I need help with my homework",
+      solved: false,
+    };
+
+    axiosMock.onPost("/api/helprequests/post").reply(202, helpRequest);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+
+    const requesterEmailInput = screen.getByLabelText("Requester Email");
+    expect(requesterEmailInput).toBeInTheDocument();
+
+    const teamIdInput = screen.getByLabelText("Team ID");
+    expect(teamIdInput).toBeInTheDocument();
+
+    const tableOrBreakoutRoomInput = screen.getByLabelText(
+      "Table or Breakout Room",
+    );
+    expect(tableOrBreakoutRoomInput).toBeInTheDocument();
+
+    const requestTimeInput = screen.getByLabelText("Request Time in UTC");
+    expect(requestTimeInput).toBeInTheDocument();
+
+    const explanationInput = screen.getByLabelText("Explanation");
+    expect(explanationInput).toBeInTheDocument();
+
+    const solvedInput = screen.getByLabelText("Solved");
+    expect(solvedInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(requesterEmailInput, {
+      target: { value: "john.doe@ucsb.edu" },
+    });
+    fireEvent.change(teamIdInput, { target: { value: 1 } });
+    fireEvent.change(tableOrBreakoutRoomInput, {
+      target: { value: "Table 5" },
+    });
+    fireEvent.change(requestTimeInput, {
+      target: { value: "2023-10-10T10:00" },
+    });
+    fireEvent.change(explanationInput, {
+      target: { value: "I need help with my homework" },
+    });
+    fireEvent.change(solvedInput, { target: { value: false } });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      requesterEmail: "john.doe@ucsb.edu",
+      teamId: "1",
+      tableOrBreakoutRoom: "Table 5",
+      requestTime: "2023-10-10T10:00",
+      explanation: "I need help with my homework",
+      solved: "false",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New help request Created - id: 3 explanation: I need help with my homework",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/helprequests" });
   });
 });

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestEditPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestEditPage.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import HelpRequestEditPage from "main/pages/HelpRequests/HelpRequestEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("HelpRequestEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("HelpRequestIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
@@ -1,15 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("HelpRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "HelpRequestTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +35,22 @@ describe("HelpRequestIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/helprequests/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +60,143 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create Help Request/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Help Request/);
+    expect(button).toHaveAttribute("href", "/helprequests/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three help requests correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createHelpRequestButton = screen.queryByText("Create Help Request");
+    expect(createHelpRequestButton).not.toBeInTheDocument();
+
+    const requesterEmail = screen.getByText("dchen451@ucsb.edu");
+    expect(requesterEmail).toBeInTheDocument();
+
+    const teamID = screen.getByText("01");
+    expect(teamID).toBeInTheDocument();
+
+    const tableOrBreakoutRoom = screen.getByText("Table 1");
+    expect(tableOrBreakoutRoom).toBeInTheDocument();
+
+    const requestTime = screen.getByText("2022-01-02T12:00:00");
+    expect(requestTime).toBeInTheDocument();
+
+    const explanation = screen.getByText(
+      "I don't understand how to do the homework",
+    );
+    expect(explanation).toBeInTheDocument();
+
+    const solved0 = screen.getByTestId(
+      "HelpRequestTable-cell-row-0-col-solved",
+    );
+    expect(solved0).toHaveTextContent("false");
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId("HelpRequestTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("HelpRequestTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/helprequests/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/helprequests/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeRequests);
+    axiosMock
+      .onDelete("/api/helprequests")
+      .reply(200, "Help Request with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("Help Request with id 1 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/helprequests");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
Closes #44 

Merge after #79 and #80

In this PR we add the HelpRequests Index page. 

To test 

1.  Visit this dokku deployment: 
https://team02-dchen451-dev.dokku-02.cs.ucsb.edu/
2. Login
3. Visit helprequests index page
4. Create and delete should work properly

Screenshots:
<img width="1629" height="294" alt="image" src="https://github.com/user-attachments/assets/93739e4e-84a0-45bd-a206-41d1d8b7f175" />

Storybook:
https://69f151d94c81672a8443275e-rpffvshave.chromatic.com/?path=/story/pages-helprequests-helprequestindexpage--empty
